### PR TITLE
Redid ingredient edit menu and added appropriate selectors

### DIFF
--- a/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
@@ -3,18 +3,24 @@ package com.example.a301project;
 import static android.content.ContentValues.TAG;
 
 import android.app.AlertDialog;
+import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.DatePicker;
 import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
+
+import java.util.Calendar;
 
 public class AddEditIngredientFragment extends DialogFragment {
     // fragment used for adding and editing an ingredient
@@ -25,6 +31,7 @@ public class AddEditIngredientFragment extends DialogFragment {
     private EditText bbdName;
     private EditText categoryName;
     private OnFragmentInteractionListener listener;
+    private DatePickerDialog.OnDateSetListener setListener;
 
     public interface OnFragmentInteractionListener {
         void onConfirmPressed(Ingredient currentIngredient, boolean createNewIngredient);
@@ -48,6 +55,11 @@ public class AddEditIngredientFragment extends DialogFragment {
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
         View view = LayoutInflater.from(getActivity()).inflate(R.layout.add_edit_ingredientlayout, null);
 
+        Calendar calendar = Calendar.getInstance();
+        final int year = calendar.get(Calendar.YEAR);
+        final int month = calendar.get(Calendar.MONTH);
+        final int day = calendar.get(Calendar.DAY_OF_MONTH);
+
         Bundle bundle = getArguments();
         if (bundle != null) {
             currentIngredient = (Ingredient) bundle.get("ingredient");
@@ -61,6 +73,26 @@ public class AddEditIngredientFragment extends DialogFragment {
         amountName = view.findViewById(R.id.edit_amount);
         unitName = view.findViewById(R.id.edit_unit);
         categoryName = view.findViewById(R.id.edit_category);
+
+        bbdName.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                DatePickerDialog datePicker = new DatePickerDialog(
+                        getActivity(), android.R.style.Theme_Holo_Light_Dialog_MinWidth,
+                        setListener, year, month, day);
+                datePicker.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+                datePicker.show();
+            }
+        });
+
+        setListener = new DatePickerDialog.OnDateSetListener() {
+            @Override
+            public void onDateSet(DatePicker datePicker, int year, int month, int dayOfMonth) {
+                month = month + 1;
+                String date = year + "-" + String.format("%02d", month) + "-" + String.format("%02d", dayOfMonth);
+                bbdName.setText(date);
+            }
+        };
 
         // set EditText boxes to the specific fields of the current selected Food
         ingredientName.setText(currentIngredient.getName());
@@ -94,7 +126,6 @@ public class AddEditIngredientFragment extends DialogFragment {
                         currentIngredient.setAmount(intAmount);
                         currentIngredient.setUnit(unit);
                         currentIngredient.setCategory(category);
-
 
                         listener.onConfirmPressed(currentIngredient, createNewIngredient);
                     }

--- a/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
@@ -13,13 +13,18 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.DatePicker;
 import android.widget.EditText;
+import android.widget.Spinner;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 
+import java.lang.reflect.Array;
 import java.util.Calendar;
 
 public class AddEditIngredientFragment extends DialogFragment {
@@ -27,7 +32,7 @@ public class AddEditIngredientFragment extends DialogFragment {
     private EditText ingredientName;
     private EditText amountName;
     private EditText locationName;
-    private EditText unitName;
+    private Spinner unitName;
     private EditText bbdName;
     private EditText categoryName;
     private OnFragmentInteractionListener listener;
@@ -74,6 +79,24 @@ public class AddEditIngredientFragment extends DialogFragment {
         unitName = view.findViewById(R.id.edit_unit);
         categoryName = view.findViewById(R.id.edit_category);
 
+        ArrayAdapter<CharSequence> spinnerAdapter = ArrayAdapter.createFromResource(this.getContext(),
+                R.array.units_array, R.layout.ingredient_unit_item);
+
+        spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        unitName.setAdapter(spinnerAdapter);
+        unitName.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                unitName.setSelection(i);
+                currentIngredient.setUnit(adapterView.getItemAtPosition(i).toString());
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+
+            }
+        });
+
         bbdName.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -98,7 +121,7 @@ public class AddEditIngredientFragment extends DialogFragment {
         ingredientName.setText(currentIngredient.getName());
         bbdName.setText(currentIngredient.getbbd());
         locationName.setText(currentIngredient.getLocation());
-        unitName.setText(currentIngredient.getUnit());
+        unitName.setSelection(spinnerAdapter.getPosition(currentIngredient.getUnit()));
         amountName.setText(currentIngredient.getAmount().toString());
         categoryName.setText(currentIngredient.getCategory());
         AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
@@ -114,7 +137,6 @@ public class AddEditIngredientFragment extends DialogFragment {
                         String bestbefore = AddEditIngredientFragment.this.bbdName.getText().toString();
                         String location = AddEditIngredientFragment.this.locationName.getText().toString();
                         String amount = AddEditIngredientFragment.this.amountName.getText().toString();
-                        String unit = AddEditIngredientFragment.this.unitName.getText().toString();
                         String category = AddEditIngredientFragment.this.categoryName.getText().toString();
                         Log.d(TAG, category);
                         Integer intAmount = Integer.valueOf(amount);
@@ -124,7 +146,6 @@ public class AddEditIngredientFragment extends DialogFragment {
                         currentIngredient.setBbd(bestbefore);
                         currentIngredient.setLocation(location);
                         currentIngredient.setAmount(intAmount);
-                        currentIngredient.setUnit(unit);
                         currentIngredient.setCategory(category);
 
                         listener.onConfirmPressed(currentIngredient, createNewIngredient);

--- a/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
@@ -19,6 +19,7 @@ import android.widget.DatePicker;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -139,13 +140,21 @@ public class AddEditIngredientFragment extends DialogFragment {
                         String amount = AddEditIngredientFragment.this.amountName.getText().toString();
                         String category = AddEditIngredientFragment.this.categoryName.getText().toString();
                         Log.d(TAG, category);
-                        Integer intAmount = Integer.valueOf(amount);
+                        Double doubleAmount = Double.valueOf(amount);
+
+                        boolean hasEmpty = ingredientName.isEmpty() || bestbefore.isEmpty() ||
+                                           location.isEmpty() || amount.isEmpty() || category.isEmpty();
+
+                        if (hasEmpty) {
+                            Toast.makeText(getContext(), "Add/Edit Rejected: Missing Field(s)",Toast.LENGTH_LONG).show();
+                            return;
+                        }
 
                         // set the name of the current food as the edited fields
                         currentIngredient.setName(ingredientName);
                         currentIngredient.setBbd(bestbefore);
                         currentIngredient.setLocation(location);
-                        currentIngredient.setAmount(intAmount);
+                        currentIngredient.setAmount(doubleAmount);
                         currentIngredient.setCategory(category);
 
                         listener.onConfirmPressed(currentIngredient, createNewIngredient);

--- a/android/301Project/app/src/main/java/com/example/a301project/Ingredient.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/Ingredient.java
@@ -13,7 +13,7 @@ public class Ingredient implements Serializable {
     private String bbd;
     private String category;
     private String unit;
-    private int amount;
+    private double amount;
 
     /**
      * Makes an {@link Ingredient} object from the given parameters
@@ -24,7 +24,7 @@ public class Ingredient implements Serializable {
      * @param unit {@link String} The unit the object uses
      * @param category {@link String} The object's category
      */
-    public Ingredient(String name, int amount, String bbd, String location, String unit, String category) {
+    public Ingredient(String name, double amount, String bbd, String location, String unit, String category) {
         // constructor
         this.name = name;
         this.location = location;
@@ -62,7 +62,7 @@ public class Ingredient implements Serializable {
      * Gets the {@link Ingredient} object's amount
      * @return The amount of the object (as an {@link Integer}
      */
-    public Integer getAmount() {return this.amount;}
+    public Double getAmount() {return this.amount;}
 
     /**
      * Gets the {@link Ingredient} object's unit
@@ -120,7 +120,7 @@ public class Ingredient implements Serializable {
      * Sets the {@link Ingredient} object's amount (as an integer)
      * @param amount The {@link Ingredient} object's amount is set to this value
      */
-    public void setAmount(Integer amount) {
+    public void setAmount(Double amount) {
         this.amount = amount;
     }
 

--- a/android/301Project/app/src/main/java/com/example/a301project/IngredientActivity.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/IngredientActivity.java
@@ -154,8 +154,17 @@ public class IngredientActivity extends NavActivity implements AddEditIngredient
                     String location = (String) doc.getData().get("Location");
                     String unit = (String) doc.getData().get("Unit");
 
-                    long amountL = (long) doc.getData().get("Amount");
-                    int amount = (int) amountL;
+                    // Get the amount. Firestore sometimes stores it as a double or as a long.
+                    // Do not know ahead of time which one, so use try catch.
+                    // TODO: Figure out a better solution than try-catch
+                    Double amount = null;
+                    try {
+                        Long amountL = (Long) doc.getData().get("Amount");
+                        amount = amountL.doubleValue();
+                    }
+                    catch(ClassCastException e) {
+                        amount = (Double) doc.getData().get("Amount");
+                    }
 
                     Ingredient newIngredient = new Ingredient(name,amount,bbd,location,unit,category);
                     newIngredient.setId(id);

--- a/android/301Project/app/src/main/java/com/example/a301project/IngredientController.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/IngredientController.java
@@ -75,7 +75,7 @@ public class IngredientController {
      */
     public void addIngredient(Ingredient ingredient) {
         // get all required values
-        int amount = ingredient.getAmount();
+        double amount = ingredient.getAmount();
         String bestBefore = ingredient.getbbd();
         String category = ingredient.getCategory();
         String location = ingredient.getLocation();

--- a/android/301Project/app/src/main/res/layout/add_edit_ingredientlayout.xml
+++ b/android/301Project/app/src/main/res/layout/add_edit_ingredientlayout.xml
@@ -10,6 +10,7 @@
         android:layout_height="wrap_content"
         android:ems="10"
         android:gravity="center_horizontal"
+        android:hint="Ingredient Name"
         android:inputType="textPersonName"
         android:padding="15dp"
         android:text="Name"
@@ -36,7 +37,8 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:ems="10"
-            android:inputType="number"
+            android:hint="Amount"
+            android:inputType="numberDecimal"
             android:text="Name" />
     </LinearLayout>
 
@@ -61,6 +63,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:ems="10"
+            android:hint="Category"
             android:inputType="textPersonName"
             android:text="Name" />
     </LinearLayout>
@@ -90,6 +93,7 @@
             android:ems="10"
             android:focusable="false"
             android:focusableInTouchMode="false"
+            android:hint="Best Before Date"
             android:inputType="textPersonName"
             android:text="Name" />
     </LinearLayout>
@@ -115,6 +119,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:ems="10"
+            android:hint="Location"
             android:inputType="textPersonName"
             android:text="Name" />
     </LinearLayout>

--- a/android/301Project/app/src/main/res/layout/add_edit_ingredientlayout.xml
+++ b/android/301Project/app/src/main/res/layout/add_edit_ingredientlayout.xml
@@ -38,7 +38,8 @@
             android:layout_marginTop="-9dp"
             android:layout_toEndOf="@+id/amount_label"
             android:layout_toRightOf="@+id/amount_label"
-            android:hint="integer"></EditText>
+            android:hint="Amount"
+            android:inputType="number"></EditText>
 
         <TextView
             android:id="@+id/bbd_label"
@@ -58,7 +59,11 @@
             android:layout_marginLeft="47dp"
             android:layout_marginTop="-7dp"
             android:layout_toRightOf="@+id/bbd_label"
-            android:hint="best before"></EditText>
+            android:clickable="false"
+            android:cursorVisible="false"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:hint="Best Before"></EditText>
 
         <TextView
             android:id="@+id/location_label"
@@ -78,7 +83,7 @@
             android:layout_marginLeft="120dp"
             android:layout_marginTop="9dp"
             android:layout_toRightOf="@+id/location_label"
-            android:hint="location"></EditText>
+            android:hint="Location"></EditText>
 
         <TextView
             android:id="@+id/unit_label"
@@ -98,7 +103,7 @@
             android:layout_marginLeft="163dp"
             android:layout_marginTop="0dp"
             android:layout_toRightOf="@+id/unit_label"
-            android:hint="unit"></EditText>
+            android:hint="Unit"></EditText>
 
         <TextView
             android:id="@+id/category_label"
@@ -118,7 +123,7 @@
             android:layout_marginLeft="117dp"
             android:layout_marginTop="1dp"
             android:layout_toRightOf="@+id/category_label"
-            android:hint="category"></EditText>
+            android:hint="Category"></EditText>
 
 
     </RelativeLayout>

--- a/android/301Project/app/src/main/res/layout/add_edit_ingredientlayout.xml
+++ b/android/301Project/app/src/main/res/layout/add_edit_ingredientlayout.xml
@@ -1,130 +1,146 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="670dp">
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+    android:layout_height="match_parent">
 
-        <EditText
-            android:id="@+id/edit_name"
-            android:layout_width="400dp"
-            android:layout_height="97dp"
-            android:layout_alignParentTop="true"
-            android:layout_centerHorizontal="true"
-            android:hint="Ingredient Name"
-            android:padding="30dp"
-            android:textSize="35dp"></EditText>
+    <EditText
+        android:id="@+id/edit_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:gravity="center_horizontal"
+        android:inputType="textPersonName"
+        android:padding="15dp"
+        android:text="Name"
+        android:textSize="34sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="@dimen/ingredient_edit_padding">
 
         <TextView
             android:id="@+id/amount_label"
-            android:layout_width="166dp"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/edit_name"
-            android:paddingLeft="50dp"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
             android:text="Amount"
-            android:textSize="20dp" />
-
+            android:textSize="20sp" />
 
         <EditText
             android:id="@+id/edit_amount"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/edit_name"
-            android:layout_marginStart="82dp"
-            android:layout_marginLeft="82dp"
-            android:layout_marginTop="-9dp"
-            android:layout_toEndOf="@+id/amount_label"
-            android:layout_toRightOf="@+id/amount_label"
-            android:hint="Amount"
-            android:inputType="number"></EditText>
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:ems="10"
+            android:inputType="number"
+            android:text="Name" />
+    </LinearLayout>
 
-        <TextView
-            android:id="@+id/bbd_label"
-            android:layout_width="wrap_content"
-            android:layout_height="37dp"
-            android:layout_below="@+id/amount_label"
-            android:layout_marginTop="12dp"
-            android:paddingLeft="50dp"
-            android:text="Best Before Date"
-            android:textSize="20dp" />
-
-        <EditText
-            android:id="@+id/edit_bbd"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/edit_amount"
-            android:layout_marginLeft="47dp"
-            android:layout_marginTop="-7dp"
-            android:layout_toRightOf="@+id/bbd_label"
-            android:clickable="false"
-            android:cursorVisible="false"
-            android:focusable="false"
-            android:focusableInTouchMode="false"
-            android:hint="Best Before"></EditText>
-
-        <TextView
-            android:id="@+id/location_label"
-            android:layout_width="wrap_content"
-            android:layout_height="37dp"
-            android:paddingLeft="50dp"
-            android:layout_below="@+id/bbd_label"
-            android:layout_marginTop="12dp"
-            android:text="Location"
-            android:textSize="20dp" />
-
-        <EditText
-            android:id="@+id/edit_location"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/edit_bbd"
-            android:layout_marginLeft="120dp"
-            android:layout_marginTop="9dp"
-            android:layout_toRightOf="@+id/location_label"
-            android:hint="Location"></EditText>
-
-        <TextView
-            android:id="@+id/unit_label"
-            android:layout_width="wrap_content"
-            android:layout_height="37dp"
-            android:paddingLeft="50dp"
-            android:layout_below="@+id/location_label"
-            android:layout_marginTop="12dp"
-            android:text="Unit"
-            android:textSize="20dp" />
-
-        <EditText
-            android:id="@+id/edit_unit"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/edit_location"
-            android:layout_marginLeft="163dp"
-            android:layout_marginTop="0dp"
-            android:layout_toRightOf="@+id/unit_label"
-            android:hint="Unit"></EditText>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="@dimen/ingredient_edit_padding">
 
         <TextView
             android:id="@+id/category_label"
-            android:layout_width="wrap_content"
-            android:layout_height="37dp"
-            android:layout_below="@+id/unit_label"
-            android:paddingLeft="50dp"
-            android:layout_marginTop="12dp"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
             android:text="Category"
-            android:textSize="20dp" />
+            android:textSize="20sp" />
 
         <EditText
             android:id="@+id/edit_category"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/edit_unit"
-            android:layout_marginLeft="117dp"
-            android:layout_marginTop="1dp"
-            android:layout_toRightOf="@+id/category_label"
-            android:hint="Category"></EditText>
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:ems="10"
+            android:inputType="textPersonName"
+            android:text="Name" />
+    </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="@dimen/ingredient_edit_padding">
 
-    </RelativeLayout>
-</FrameLayout>
+        <TextView
+            android:id="@+id/bbd_label"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:text="Best Before"
+            android:textSize="20sp" />
+
+        <EditText
+            android:id="@+id/edit_bbd"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:clickable="false"
+            android:cursorVisible="false"
+            android:ems="10"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:inputType="textPersonName"
+            android:text="Name" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="@dimen/ingredient_edit_padding">
+
+        <TextView
+            android:id="@+id/location_label"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:text="Location"
+            android:textSize="20sp" />
+
+        <EditText
+            android:id="@+id/edit_location"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:ems="10"
+            android:inputType="textPersonName"
+            android:text="Name" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="@dimen/ingredient_edit_padding">
+
+        <TextView
+            android:id="@+id/unit_label"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:text="Units"
+            android:textSize="20sp" />
+
+        <Spinner
+            android:id="@+id/edit_unit"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:padding="5sp" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/android/301Project/app/src/main/res/layout/ingredient_unit_item.xml
+++ b/android/301Project/app/src/main/res/layout/ingredient_unit_item.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textSize="18sp"
+    android:gravity="left"
+    android:textColor="@color/black">
+
+</TextView>

--- a/android/301Project/app/src/main/res/values/dimens.xml
+++ b/android/301Project/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="ingredient_edit_padding">10dp</dimen>
+</resources>

--- a/android/301Project/app/src/main/res/values/strings.xml
+++ b/android/301Project/app/src/main/res/values/strings.xml
@@ -1,3 +1,11 @@
 <resources>
     <string name="app_name">301Project</string>
+    <string-array name="units_array">
+        <item>Pieces</item>
+        <item>Slices</item>
+        <item>Grams</item>
+        <item>lbs</item>
+        <item>Ounces</item>
+        <item>Cups</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
Cleaned up the ingredient edit menu using vertical and horizontal layouts which results in more even and consistent spacing between items.

Other changes:
- Added calendar selector for best before date
- Changed unit selector to a selection spinner (with a custom spinner item)
- Changed amount selector to only accept numbers

Resolves #55

<img width="485" alt="image" src="https://user-images.githubusercontent.com/52058352/199339497-28599666-0fb2-438c-9b95-7f5b416cb170.png">
<img width="485" alt="image" src="https://user-images.githubusercontent.com/52058352/199338814-818317d2-16ba-493c-ac8e-5f6cceac6a20.png">
<img width="485" alt="image" src="https://user-images.githubusercontent.com/52058352/199338895-daf545b0-ff98-44d0-82bc-2007a7514672.png">