### PR TITLE
Added ingredient delete button

### DIFF
--- a/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
@@ -15,6 +15,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.DatePicker;
 import android.widget.EditText;
 import android.widget.Spinner;
@@ -24,6 +25,9 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentTransaction;
 
 import java.lang.reflect.Array;
 import java.util.Calendar;
@@ -38,6 +42,7 @@ public class AddEditIngredientFragment extends DialogFragment {
     private EditText categoryName;
     private OnFragmentInteractionListener listener;
     private DatePickerDialog.OnDateSetListener setListener;
+    private Button deleteButton;
 
     public interface OnFragmentInteractionListener {
         void onConfirmPressed(Ingredient currentIngredient, boolean createNewIngredient);
@@ -79,6 +84,29 @@ public class AddEditIngredientFragment extends DialogFragment {
         amountName = view.findViewById(R.id.edit_amount);
         unitName = view.findViewById(R.id.edit_unit);
         categoryName = view.findViewById(R.id.edit_category);
+        deleteButton = view.findViewById(R.id.delete_ingredient_button);
+
+        String title;
+        if (this.getTag().equals("ADD")) {
+            title = "Add Entry";
+            deleteButton.setVisibility(View.GONE);
+        }
+        else {
+            title = "Edit Entry";
+        }
+
+        deleteButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                IngredientController controller = new IngredientController();
+                controller.removeIngredient(currentIngredient);
+
+                Fragment frag = getActivity().getSupportFragmentManager().findFragmentByTag("EDIT");
+                getActivity().getSupportFragmentManager().beginTransaction().remove(frag).commit();
+
+                Toast.makeText(getContext(), "Ingredient Delete Successful", Toast.LENGTH_LONG).show();
+            }
+        });
 
         ArrayAdapter<CharSequence> spinnerAdapter = ArrayAdapter.createFromResource(this.getContext(),
                 R.array.units_array, R.layout.ingredient_unit_item);
@@ -128,7 +156,7 @@ public class AddEditIngredientFragment extends DialogFragment {
         AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
         return builder
                 .setView(view)
-                .setTitle("Add/Edit Entry")
+                .setTitle(title)
                 .setNegativeButton("Cancel",null)
                 .setPositiveButton("Confirm", new DialogInterface.OnClickListener() {
                     @Override

--- a/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
@@ -98,13 +98,27 @@ public class AddEditIngredientFragment extends DialogFragment {
         deleteButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                IngredientController controller = new IngredientController();
-                controller.removeIngredient(currentIngredient);
 
-                Fragment frag = getActivity().getSupportFragmentManager().findFragmentByTag("EDIT");
-                getActivity().getSupportFragmentManager().beginTransaction().remove(frag).commit();
+                AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+                builder.setMessage("Are you sure you want to delete this ingredient?")
+                        .setCancelable(false)
+                        .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                IngredientController controller = new IngredientController();
+                                controller.removeIngredient(currentIngredient);
 
-                Toast.makeText(getContext(), "Ingredient Delete Successful", Toast.LENGTH_LONG).show();
+                                Fragment frag = getActivity().getSupportFragmentManager().findFragmentByTag("EDIT");
+                                getActivity().getSupportFragmentManager().beginTransaction().remove(frag).commit();
+                                Toast.makeText(getContext(), "Ingredient Delete Successful", Toast.LENGTH_LONG).show();
+                            }
+                        })
+                        .setNegativeButton("No", new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                dialog.cancel();
+                            }
+                        });
+                AlertDialog alert = builder.create();
+                alert.show();
             }
         });
 

--- a/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
@@ -174,7 +174,7 @@ public class AddEditIngredientFragment extends DialogFragment {
                                            location.isEmpty() || amount.isEmpty() || category.isEmpty();
 
                         if (hasEmpty) {
-                            Toast.makeText(getContext(), "Add/Edit Rejected: Missing Field(s)",Toast.LENGTH_LONG).show();
+                            Toast.makeText(getContext(),  title + " Rejected: Missing Field(s)",Toast.LENGTH_LONG).show();
                             return;
                         }
 

--- a/android/301Project/app/src/main/res/layout/add_edit_ingredientlayout.xml
+++ b/android/301Project/app/src/main/res/layout/add_edit_ingredientlayout.xml
@@ -148,4 +148,18 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        android:padding="15dp">
+
+        <Button
+            android:id="@+id/delete_ingredient_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Delete Ingredient" />
+    </LinearLayout>
+
 </LinearLayout>


### PR DESCRIPTION
Added the ingredient delete button (finally!)
When the ingredient edit screen is up, you have the option to delete the ingredient from the database.

Major changes:
- Added delete button
- Changed the title of the add/edit fragment based on whether you are adding or editing (also the add/edit reject message)
- Delete button will not appear when adding a food, only when editing
- Delete confirmation dialog will popup when the delete button is pressed

Resolves #4 

Adding the entry:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/52058352/199359575-2b27e22e-ebb5-4667-a2c9-67f6cbd19d6f.png">

Editing the entry:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/52058352/199359620-dcdf9950-c7e1-4b44-a733-82a98929d6ba.png">

Delete confirmation:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/52058352/199359659-809a50e1-a9e8-430b-b7c2-08c4cf87bb12.png">

Delete successful:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/52058352/199359815-99a47fa0-e5bb-442a-a838-0be8e04c5d04.png">
