### PR TITLE
Refactor All Activities to Fragments

### DIFF
--- a/android/301Project/.idea/.gitignore
+++ b/android/301Project/.idea/.gitignore
@@ -1,3 +1,4 @@
 # Default ignored files
 /shelf/
 /workspace.xml
+/misc.xml

--- a/android/301Project/app/src/androidTest/java/com/example/a301project/IngredientFragmentTest.java
+++ b/android/301Project/app/src/androidTest/java/com/example/a301project/IngredientFragmentTest.java
@@ -2,6 +2,7 @@ package com.example.a301project;
 
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import android.widget.EditText;
@@ -24,15 +25,15 @@ import java.util.Locale;
 
 
 /**
- * Test class for IngredientActivity. Robotium framework is used
+ * Test class for IngredientFragment. Robotium framework is used
  */
 @RunWith(AndroidJUnit4.class)
-public class IngredientActivityTest {
+public class IngredientFragmentTest {
 
     private Solo solo;
 
     @Rule
-    public ActivityTestRule<IngredientActivity> rule = new ActivityTestRule<>(IngredientActivity.class,
+    public ActivityTestRule<NavActivity> rule = new ActivityTestRule<>(NavActivity.class,
             true, true);
 
     /**
@@ -45,24 +46,24 @@ public class IngredientActivityTest {
     }
 
     /**
-     * Check that the IngredientActivity opens
+     * Check that the IngredientFragment opens
      */
     @Test
-    public void testThatIngredientActivityIsOpen() {
-        // Asserts that the current activity is the IngredientActivity.
-        solo.assertCurrentActivity("IngredientActivity did not open on startup", IngredientActivity.class);
+    public void testThatIngredientFragmentIsOpen() {
+        // Asserts that the current fragment is the IngredientFragment.
+        assertNotNull(rule.getActivity().getSupportFragmentManager().findFragmentByTag("IngredientFragment"));
     }
 
     /**
      * Test that the ADD ingredient button works
      * Steps:
-     * 1. Check that IngredientActivity is open
+     * 1. Check that IngredientFragment is open
      * 2. Click on Add button
      * 3. Check that the add ingredient popup is showing
      */
     @Test
     public void testAddButtonFunctionality() {
-        testThatIngredientActivityIsOpen();
+        testThatIngredientFragmentIsOpen();
 
         // Click on button
         solo.clickOnButton("Add");
@@ -75,7 +76,7 @@ public class IngredientActivityTest {
     /**
      * Tests that the Ascending switch can be toggled
      * Steps:
-     * 1. Check that IngredientActivity is open
+     * 1. Check that IngredientFragment is open
      * 2. Ensure that the Ascending switch starting state is CHECKED
      * 3. Toggle the Ascending switch
      * 4. Check that Ascending switch starting state is NOT CHECKED
@@ -86,8 +87,7 @@ public class IngredientActivityTest {
     @Test
     public void testTogglingAscendingSwitch() {
 
-        // Asserts that the current activity is the IngredientActivity.
-        solo.assertCurrentActivity("Not in IngredientActivity", IngredientActivity.class);
+        // Asserts that the current activity is the IngredientFragment.
 
         // get the switch
         Switch ascendingSwitch = (Switch) solo.getView(R.id.ingredientSortSwitch);
@@ -103,16 +103,16 @@ public class IngredientActivityTest {
      * Tests that the Name value is the default value in the SortBy {@link android.widget.Spinner}
      * in Ingredient Activity
      * Steps:
-     * 1. Check that IngredientActivity is open
+     * 1. Check that IngredientFragment is open
      * 2. Check that the Name value is the selected in the SortBy {@link android.widget.Spinner}
      */
     @Test
     public void testThatNameIsDefaultSortBySelection() {
-        // check that IngredientActivity is open
-        testThatIngredientActivityIsOpen();
+        // check that IngredientFragment is open
+        testThatIngredientFragmentIsOpen();
 
         // check that the item was selected
-        assertTrue("{Name} was not the default selection for the Sort By spinner in IngredientActivityCategory",
+        assertTrue("{Name} was not the default selection for the Sort By spinner in IngredientFragmentCategory",
                 solo.waitForText("Name", 1, 2000));
     }
 
@@ -120,14 +120,14 @@ public class IngredientActivityTest {
      * Tests that the Location value can be selected in the SortBy {@link android.widget.Spinner}
      * in Ingredient Activity
      * Steps:
-     * 1. Check that IngredientActivity is open
+     * 1. Check that IngredientFragment is open
      * 2. Check that Name value is currently selected in the Sort By {@link android.widget.Spinner}
      * 3. Open the spinner and select the Location value
      * 4. Check that the Location value is the selected in the Sort By {@link android.widget.Spinner}
      */
     @Test
     public void testSelectingLocationFromSortBySpinner() {
-        // ensure that IngredientActivity is open and Name is the default value for the Sort By spinner
+        // ensure that IngredientFragment is open and Name is the default value for the Sort By spinner
         testThatNameIsDefaultSortBySelection();
 
         // click on spinner and select the item
@@ -135,7 +135,7 @@ public class IngredientActivityTest {
         solo.clickOnText("Location");
 
         // check that the item was selected
-        assertTrue("{Location} value was not able to be selected from the Sort By Spinner in IngredientActivity",
+        assertTrue("{Location} value was not able to be selected from the Sort By Spinner in IngredientFragment",
                 solo.waitForText("Location", 1, 2000));
     }
 
@@ -143,14 +143,14 @@ public class IngredientActivityTest {
      * Tests that the Expiry value can be selected in the SortBy {@link android.widget.Spinner}
      * in Ingredient Activity
      * Steps:
-     * 1. Check that IngredientActivity is open
+     * 1. Check that IngredientFragment is open
      * 2. Check that Name value is currently selected in the Sort By spinner
      * 3. Open the spinner and select the Expiry value
      * 4. Check that the Expiry value is the selected in the Sort By  {@link android.widget.Spinner}
      */
     @Test
     public void testSelectingExpiryFromSortBySpinner() {
-        // ensure that IngredientActivity is open and Name is the default value for the Sort By spinner
+        // ensure that IngredientFragment is open and Name is the default value for the Sort By spinner
         testThatNameIsDefaultSortBySelection();
 
         // click on spinner and select the item
@@ -158,7 +158,7 @@ public class IngredientActivityTest {
         solo.clickOnText("Expiry");
 
         // check that the item was selected
-        assertTrue("{Expiry} value was not able to be selected from the Sort By Spinner in IngredientActivity",
+        assertTrue("{Expiry} value was not able to be selected from the Sort By Spinner in IngredientFragment",
                 solo.waitForText("Expiry", 1, 2000));
 
     }
@@ -167,14 +167,14 @@ public class IngredientActivityTest {
      * Tests that the Category value can be selected in the SortBy {@link android.widget.Spinner}
      * in Ingredient Activity
      * Steps:
-     * 1. Check that IngredientActivity is open
+     * 1. Check that IngredientFragment is open
      * 2. Check that Name value is currently selected in the Sort By spinner
      * 3. Open the spinner and select the Category value
      * 4. Check that the Category value is the selected in the Sort By  {@link android.widget.Spinner}
      */
     @Test
     public void testSelectingCategoryFromSortBySpinner() {
-        // ensure that IngredientActivity is open and Name is the default value for the Sort By spinner
+        // ensure that IngredientFragment is open and Name is the default value for the Sort By spinner
         testThatNameIsDefaultSortBySelection();
 
         // click on spinner and select the item
@@ -182,7 +182,7 @@ public class IngredientActivityTest {
         solo.clickOnText("Category");
 
         // check that the item was selected
-        assertTrue("{Category} value was not able to be selected from the Sort By Spinner in IngredientActivity",
+        assertTrue("{Category} value was not able to be selected from the Sort By Spinner in IngredientFragment",
                 solo.waitForText("Category", 1, 2000));
 
     }
@@ -336,17 +336,17 @@ public class IngredientActivityTest {
         // click confirm button
         solo.clickOnButton("Confirm");
 
-        // check that fragment closed and the IngredientActivity is displayed
+        // check that fragment closed and the IngredientFragment is displayed
         assertFalse("Add Ingredient fragment not closed when pressed Confirm Button after filling out all fields correctly",
                 solo.waitForText("Add Entry", 1, 2000));
-        solo.assertCurrentActivity("IngredientActivity not displayed after adding ingredient", IngredientActivity.class);
+        testThatIngredientFragmentIsOpen();
     }
 
     /**
      * Open fragment, fill out fields, and confirm, checks that ingredient was added
      * Steps:
      * 1. Open fragment and fill out fields and click confirm button (uses previous test)
-     * 2. Check that the ingredient info is displayed in IngredientActivity
+     * 2. Check that the ingredient info is displayed in IngredientFragment
      */
     @Test
     public void testAddingCorrectIngredient() {
@@ -355,7 +355,7 @@ public class IngredientActivityTest {
 
         // scroll down until the name of the ingredient is found
         assertTrue("Added an Ingredient and it cannot be found in Ingredient Activity",
-                scrollIngredientActivityUntilIngredientIsFound("Pineapple", "3.5", "Grain",
+                scrollIngredientFragmentUntilIngredientIsFound("Pineapple", "3.5", "Grain",
                         "2022-11-03", "Cabinet", "Slices"));
     }
 
@@ -520,8 +520,8 @@ public class IngredientActivityTest {
         solo.clickOnButton("Confirm");
 
         // check that error message is shown (or that fragment didn't close)
-        //assertFalse("Error in Add fragment when trying to Add Ingredient with empty bbd",
-        // solo.waitForText("Add Entry Rejected: Missing Field(s)", 1, 2000));
+        assertFalse("Error in Add fragment when trying to Add Ingredient with empty bbd",
+         solo.waitForText("Add Entry Rejected: Missing Field(s)", 1, 2000));
     }
 
     /**
@@ -556,7 +556,7 @@ public class IngredientActivityTest {
      * @param unit the unit {@link String} of the ingredient {@link Ingredient}
      * @return
      */
-    public boolean scrollIngredientActivityUntilIngredientIsFound(String name, String amount, String category,
+    public boolean scrollIngredientFragmentUntilIngredientIsFound(String name, String amount, String category,
                                                                   String bbd, String location, String unit){
         // start off at the top
         boolean scrollMore = true;
@@ -689,7 +689,7 @@ public class IngredientActivityTest {
     public void testClickingYesButtonOnDeleteIngredientConfirmationDialog() {
         testClickingDeleteIngredientButton();
 
-        // press NO
+        // press Yes
         solo.clickOnText("Yes");
 
         // check that Edit Ingredient framework is displayed
@@ -708,22 +708,7 @@ public class IngredientActivityTest {
 
         solo.clickOnText("Confirm");
         solo.sleep(300);
-        //assertTrue("Did not correctly show error message after trying to save edited item with empty name",
-               // solo.waitForText("Edit Entry Rejected: Missing Field(s)", 1, 1000));
+        assertTrue("Did not correctly show error message after trying to save edited item with empty name",
+                solo.waitForText("Edit Entry Rejected: Missing Field(s)", 1, 1000));
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 }

--- a/android/301Project/app/src/androidTest/java/com/example/a301project/NavActivityTest.java
+++ b/android/301Project/app/src/androidTest/java/com/example/a301project/NavActivityTest.java
@@ -1,7 +1,7 @@
 package com.example.a301project;
 
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 import android.app.Activity;
 
@@ -56,67 +56,66 @@ public class NavActivityTest {
     }
 
     /**
-     * Tests that the IngredientActivity can open when the it's selected in the menu
+     * Tests that the IngredientFragment can open when the it's selected in the menu
      */
     @Test
-    public void openIngredientActivity() {
+    public void openIngredientFragment() {
         // Asserts that the current activity is the NavActivity. Otherwise show "Wrong Activity"
         solo.assertCurrentActivity("Not in NavActivity", NavActivity.class);
 
         // Click on button
         solo.clickOnMenuItem("Ingredients");
 
-        // check if IngredientActivity opens
-        assertTrue(solo.waitForText("My Ingredients", 1, 2000));
-        solo.assertCurrentActivity("Did not open IngredientActivity", IngredientActivity.class);
+        // check if IngredientFragment opens
+        assertNotNull(rule.getActivity().getSupportFragmentManager().findFragmentByTag("IngredientFragment"));
     }
 
     /**
-     * Tests that the RecipeActivity can open when the it's selected in the menu
+     * Tests that the RecipeFragment can open when the it's selected in the menu
      */
     @Test
-    public void openRecipeActivity() {
+    public void openRecipeFragment() {
         // Asserts that the current activity is the NavActivity. Otherwise show "Wrong Activity"
         solo.assertCurrentActivity("Not in NavActivity", NavActivity.class);
 
         // Click on button
         solo.clickOnMenuItem("Recipes");
 
-        // check if IngredientActivity opens
-        assertTrue(solo.waitForText("My Recipes", 1, 2000));
-        solo.assertCurrentActivity("Did not open RecipeActivity", RecipeActivity.class);
+        // check if RecipeFragment opens
+        solo.waitForText("My Recipes");
+        assertNotNull(rule.getActivity().getSupportFragmentManager().findFragmentByTag("RecipeFragment"));
     }
 
     /**
-     * Tests that the MealPlanActivity can open when the it's selected in the menu
+     * Tests that the MealPlanFragment can open when the it's selected in the menu
      */
     @Test
-    public void openMealPlanActivity() {
+    public void openMealPlanFragment() {
         // Asserts that the current activity is the NavActivity. Otherwise show "Wrong Activity"
         solo.assertCurrentActivity("Not in NavActivity", NavActivity.class);
 
         // Click on button
         solo.clickOnMenuItem("Meal Plan");
 
-        // check if IngredientActivity opens
-        assertTrue(solo.waitForText("My Meal Plans", 1, 2000));
-        solo.assertCurrentActivity("Did not open MealPlanActivity", MealPlanActivity.class);
+        // check if MealPlanFragment opens
+        solo.waitForText("My Meal Plans");
+        assertNotNull(rule.getActivity().getSupportFragmentManager().findFragmentByTag("MealPlanFragment"));
     }
 
     /**
-     * Tests that the ShoppingListActivity can open when the it's selected in the menu
+     * Tests that the ShoppingListFragment can open when the it's selected in the menu
      */
     @Test
-    public void openShoppingListActivity() {
+    public void openShoppingListFragment() {
         // Asserts that the current activity is the NavActivity. Otherwise show "Wrong Activity"
         solo.assertCurrentActivity("Not in NavActivity", NavActivity.class);
 
         // Click on button
         solo.clickOnMenuItem("Shopping List");
 
-        // check if IngredientActivity opens
-        assertTrue(solo.waitForText("My Shopping List", 1, 2000));
-        solo.assertCurrentActivity("Did not open ShoppingListActivity", ShoppingListActivity.class);
+        // check if ShoppingListFragment opens
+        solo.waitForText("My Shopping List");
+        assertNotNull(rule.getActivity().getSupportFragmentManager().findFragmentByTag("ShoppingListFragment"));
 
     }
 

--- a/android/301Project/app/src/main/AndroidManifest.xml
+++ b/android/301Project/app/src/main/AndroidManifest.xml
@@ -14,30 +14,14 @@
         android:theme="@style/Theme.301Project"
         tools:targetApi="31">
         <activity
-            android:name=".ShoppingListActivity"
-            android:exported="false"
-            android:label="My Shopping List" />
-        <activity
-            android:name=".RecipeActivity"
-            android:exported="false"
-            android:label="My Recipes" />
-        <activity
-            android:name=".MealPlanActivity"
+            android:name=".NavActivity"
             android:exported="true"
-            android:label="My Meal Plans" />
-        <activity
-            android:name=".IngredientActivity"
-            android:exported="true"
-            android:label="My Ingredients">
+            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".NavActivity"
-            android:exported="false" />
     </application>
 
 </manifest>

--- a/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/AddEditIngredientFragment.java
@@ -1,16 +1,12 @@
 package com.example.a301project;
 
-import static android.content.ContentValues.TAG;
-
 import android.app.AlertDialog;
 import android.app.DatePickerDialog;
 import android.app.Dialog;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.AdapterView;
@@ -19,17 +15,13 @@ import android.widget.Button;
 import android.widget.DatePicker;
 import android.widget.EditText;
 import android.widget.Spinner;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentTransaction;
 
-import java.lang.reflect.Array;
 import java.util.Calendar;
 
 /**
@@ -47,6 +39,8 @@ public class AddEditIngredientFragment extends DialogFragment {
     private OnFragmentInteractionListener listener;
     private DatePickerDialog.OnDateSetListener setListener;
     private Button deleteButton;
+    private Ingredient currentIngredient;
+    private boolean createNewIngredient;
 
     /**
      * Method that responds when the fragment has been interacted with
@@ -56,24 +50,7 @@ public class AddEditIngredientFragment extends DialogFragment {
         void onConfirmPressed(Ingredient currentIngredient, boolean createNewIngredient);
     }
 
-    /**
-     * Method for when fragment is attached to the screen
-     * @param context {@link Context} the context of the fragment
-     * sets the listener object as OnFragmentInteractionListener
-     * throws exception if context is not an instance of OnFragmentInteractionListener
-     */
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        if (context instanceof AddEditIngredientFragment.OnFragmentInteractionListener) {
-            listener = (AddEditIngredientFragment.OnFragmentInteractionListener) context;
-        } else {
-            throw new RuntimeException(context.toString() + "must implement OnFragmentInteractionListener");
-        }
-    }
 
-    Ingredient currentIngredient;
-    boolean createNewIngredient;
 
     /**
      * Method to set the fragment attributes
@@ -136,8 +113,8 @@ public class AddEditIngredientFragment extends DialogFragment {
                                 IngredientController controller = new IngredientController();
                                 controller.removeIngredient(currentIngredient);
 
-                                Fragment frag = getActivity().getSupportFragmentManager().findFragmentByTag("EDIT");
-                                getActivity().getSupportFragmentManager().beginTransaction().remove(frag).commit();
+                                Fragment frag = getParentFragmentManager().findFragmentByTag("EDIT");
+                                getParentFragmentManager().beginTransaction().remove(frag).commit();
                                 Toast.makeText(getContext(), "Ingredient Delete Successful", Toast.LENGTH_LONG).show();
                             }
                         })
@@ -333,13 +310,15 @@ public class AddEditIngredientFragment extends DialogFragment {
      * @param createNew {@link boolean} variable that indicates whether to create a new ingredient
      * @return An Add/Edit Ingredient fragment
      */
-    static AddEditIngredientFragment newInstance(Ingredient ingredient, boolean createNew) {
+    static AddEditIngredientFragment newInstance(Ingredient ingredient, boolean createNew, OnFragmentInteractionListener listener) {
         Bundle args = new Bundle();
         args.putSerializable("ingredient",ingredient);
         args.putSerializable("createNew", createNew);
 
         AddEditIngredientFragment fragment = new AddEditIngredientFragment();
         fragment.setArguments(args);
+
+        fragment.listener = listener;
         return fragment;
     }
 }

--- a/android/301Project/app/src/main/java/com/example/a301project/AddEditRecipeFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/AddEditRecipeFragment.java
@@ -3,7 +3,6 @@ package com.example.a301project;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -29,7 +28,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
-
 
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -117,23 +115,6 @@ public class AddEditRecipeFragment extends DialogFragment {
     }
 
     /**
-     * Method for when fragment is attached to the screen
-     * @param context {@link Context} the context of the fragment
-     * sets the listener object as OnFragmentInteractionListener
-     * throws exception if context is not an instance of OnFragmentInteractionListener
-     */
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        if (context instanceof AddEditRecipeFragment.OnFragmentInteractionListener) {
-            listener = (AddEditRecipeFragment.OnFragmentInteractionListener) context;
-        }
-        else {
-            throw new RuntimeException(context + "must implement OnFragmentInteractionListener");
-        }
-    }
-
-    /**
      * Method to set the fragment attributes
      * Sets the information of current Recipe if the tag is EDIT
      * Sets empty EditText views if the tag is ADD, and hides delete button
@@ -191,8 +172,8 @@ public class AddEditRecipeFragment extends DialogFragment {
                                 RecipeController controller = new RecipeController();
                                 controller.removeRecipe(currentRecipe);
                                 listener.onDeleteConfirmed(currentRecipe);
-                                Fragment frag = getActivity().getSupportFragmentManager().findFragmentByTag("EDIT");
-                                getActivity().getSupportFragmentManager().beginTransaction().remove(frag).commit();
+                                Fragment frag = getParentFragmentManager().findFragmentByTag("EDIT");
+                                getParentFragmentManager().beginTransaction().remove(frag).commit();
                                 Toast.makeText(getContext(), "Recipe Delete Successful", Toast.LENGTH_LONG).show();
                             }
                         })
@@ -367,13 +348,15 @@ public class AddEditRecipeFragment extends DialogFragment {
      * @param createNew {@link boolean} variable that indicates whether to create a new recipe
      * @return An Add/Edit Recipe fragment
      */
-    static AddEditRecipeFragment newInstance(Recipe recipe, boolean createNew) {
+    static AddEditRecipeFragment newInstance(Recipe recipe, boolean createNew , OnFragmentInteractionListener listener) {
         Bundle args = new Bundle();
         args.putSerializable("recipe",recipe);
         args.putSerializable("createNew", createNew);
 
         AddEditRecipeFragment fragment = new AddEditRecipeFragment();
         fragment.setArguments(args);
+        fragment.listener = listener;
+
         return fragment;
     }
 }

--- a/android/301Project/app/src/main/java/com/example/a301project/CustomList.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/CustomList.java
@@ -34,31 +34,22 @@ public class CustomList extends ArrayAdapter<Ingredient> {
     }
 
     /**
-<<<<<<< HEAD
      * Method for creating a view that will appear in the ingredient adapter
      * @param position {@link Integer} the position of the current view
      * @param convertView {@link View} the reused view to be retrieved
      * @param parent {@link ViewGroup} the collection of views that contains current view
      * @return a view
-=======
-     *
-     * @param position {@link Integer} the position of the current view
-     * @param convertView {@link View} the view to be retrieved
-     * @param parent {@link ViewGroup} the collection of views that contains
-     * @return the view that is selected
->>>>>>> 9af36dcb74ba57f887d7bdfc49103e27fadc927d
      */
     @NonNull
     @Override
     public View getView(int position, @Nullable View convertView, @NonNull ViewGroup
             parent) {
-        // return super.getView(position, convertView, parent);
         View view = convertView;
         if(view == null){
             view = LayoutInflater.from(context).inflate(R.layout.ingredient_content, parent,false);
         }
         // list view to display attributes of each ingredient object
-        // by setting the view textboxes to their ID
+        // by setting the view text boxes to their ID
         Ingredient ingredient = ingredients.get(position);
         TextView ingredientName = view.findViewById(R.id.i_nameText);
         TextView locationName = view.findViewById(R.id.i_locationText);

--- a/android/301Project/app/src/main/java/com/example/a301project/IngredientFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/IngredientFragment.java
@@ -2,7 +2,6 @@ package com.example.a301project;
 
 import android.os.Bundle;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -11,9 +10,10 @@ import android.widget.ListView;
 import android.widget.Spinner;
 import android.widget.Switch;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 
-import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestoreException;
@@ -25,17 +25,16 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.Locale;
 
 /**
  * Main Activity class for Ingredients
  * functionalities for add, edit, delete
  * initiates an IngredientController object that has access to firebase data
  * handles sorting of ingredients
- * @return void
+ * void
  */
 
-public class IngredientActivity extends NavActivity implements AddEditIngredientFragment.OnFragmentInteractionListener {
+public class IngredientFragment extends Fragment implements AddEditIngredientFragment.OnFragmentInteractionListener {
     private IngredientController ingredientController;
     private ListView ingredientList;
     private ArrayAdapter<Ingredient> ingredientAdapter;
@@ -45,40 +44,34 @@ public class IngredientActivity extends NavActivity implements AddEditIngredient
     private Switch sortSwitch;
     public int position = -1;
     private Button addButton;
-    /**
-     * Method for the activity becomes active and can receive input
-     * Navigation panel finds the menu and displays it
-     */
-    @Override
-    protected void onResume() {
-        super.onResume();
-        bottomNav.getMenu().findItem(R.id.action_ingredients).setChecked(true);
+
+    public IngredientFragment() {
+        super(R.layout.activity_ingredient);
     }
 
     /**
      * Method for initializing attributes of this activity
+     * @param view The View returned by onCreateView.f
      * @param savedInstanceState {@link Bundle} the last saved instance of the fragment, NULL if newly created
      */
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        // We have to put our layout in the space for the content
-        ViewGroup content = findViewById(R.id.nav_content);
-        getLayoutInflater().inflate(R.layout.activity_ingredient, content, true);
+        getActivity().setTitle("My Ingredients");
 
-        addButton = findViewById(R.id.add_ingredient_button);
+        addButton = view.findViewById(R.id.add_ingredient_button);
         // create list of ingredients
-        ingredientList = findViewById(R.id.ingredientListView);
+        ingredientList = view.findViewById(R.id.ingredientListView);
         dataList = new ArrayList<>();
 
-        ingredientAdapter = new CustomList(this,dataList);
+        ingredientAdapter = new CustomList(getContext(),dataList);
         ingredientList.setAdapter(ingredientAdapter);
 
 
         // ingredient sort by title, location, expiry date, category
-        sortSpinner = findViewById(R.id.ingredientSortSpinner);
-        sortSwitch = findViewById(R.id.ingredientSortSwitch);
-        ArrayAdapter<String> sortAdapter = new ArrayAdapter<>(this,com.google.android.material.R.layout.support_simple_spinner_dropdown_item, sortOptions);
+        sortSpinner = view.findViewById(R.id.ingredientSortSpinner);
+        sortSwitch = view.findViewById(R.id.ingredientSortSwitch);
+        ArrayAdapter<String> sortAdapter = new ArrayAdapter<>(getContext(),com.google.android.material.R.layout.support_simple_spinner_dropdown_item, sortOptions);
         sortSpinner.setAdapter(sortAdapter);
         sortSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             /**
@@ -117,7 +110,6 @@ public class IngredientActivity extends NavActivity implements AddEditIngredient
                 sortDataBySpinner();
             }
         });
-        sortDataBySpinner();
 
         // on item  click in ingredient list, editor appears
         ingredientList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
@@ -133,7 +125,8 @@ public class IngredientActivity extends NavActivity implements AddEditIngredient
                 // view ingredient details when you click on it
                 position = i;
                 Ingredient selected = (Ingredient) adapterView.getItemAtPosition(i);
-                AddEditIngredientFragment.newInstance(ingredientAdapter.getItem(position),false).show(getSupportFragmentManager(),"EDIT");
+
+                AddEditIngredientFragment.newInstance(ingredientAdapter.getItem(position),false, IngredientFragment.this).show(getChildFragmentManager(),"EDIT");
 
             }
         });
@@ -148,7 +141,7 @@ public class IngredientActivity extends NavActivity implements AddEditIngredient
             @Override
             public void onClick(View view) {
                 Ingredient newIngredient = new Ingredient("",1,"","","","");
-                AddEditIngredientFragment.newInstance(newIngredient,true).show(getSupportFragmentManager(),"ADD");
+                AddEditIngredientFragment.newInstance(newIngredient,true, IngredientFragment.this).show(getChildFragmentManager(),"ADD");
             }
         });
 
@@ -186,12 +179,10 @@ public class IngredientActivity extends NavActivity implements AddEditIngredient
 
                     dataList.add(newIngredient);
                 }
+                sortDataBySpinner();
                 ingredientAdapter.notifyDataSetChanged();
             }
         });
-
-        // Set the correct button to be selected
-        bottomNav.getMenu().findItem(R.id.action_ingredients).setChecked(true);
     }
     /**
      * Method for sorting ingredients by selected attributes
@@ -200,8 +191,8 @@ public class IngredientActivity extends NavActivity implements AddEditIngredient
      * @return void
      */
     public void sortDataBySpinner() {
-        sortSpinner = findViewById(R.id.ingredientSortSpinner);
-        sortSwitch = findViewById(R.id.ingredientSortSwitch);
+        sortSpinner = getView().findViewById(R.id.ingredientSortSpinner);
+        sortSwitch = getView().findViewById(R.id.ingredientSortSwitch);
 
         // retrieve the sort information
         String sortBy = sortSpinner.getSelectedItem().toString();

--- a/android/301Project/app/src/main/java/com/example/a301project/MealPlan.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/MealPlan.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 
 /**
  * Represents an individual meal plan with ingredients and recipes.
- * MealPlanActivity contains multiple instances of these.
+ * MealPlanFragment contains multiple instances of these.
  */
 public class MealPlan {
     private ArrayList<Ingredient> ingredients;

--- a/android/301Project/app/src/main/java/com/example/a301project/MealPlanFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/MealPlanFragment.java
@@ -1,15 +1,17 @@
 package com.example.a301project;
 
 import android.os.Bundle;
-import android.util.Log;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
 import java.time.DayOfWeek;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Locale;
 
 /**
@@ -18,19 +20,13 @@ import java.util.Locale;
  * renders MealPlan for user and allows them to add, delete, modify it
  * currently incomplete
  */
-public class MealPlanActivity extends NavActivity {
+public class MealPlanFragment extends Fragment {
     private ListView listView;
     private ArrayAdapter<MealPlan> mealPlanArrayAdapter;
     private ArrayList<MealPlan> mealPlanDataList = new ArrayList<>();
 
-    /**
-     * Method for the activity becomes active and can receive input
-     * Navigation panel finds the menu and displays it
-     */
-    @Override
-    protected void onResume() {
-        super.onResume();
-        bottomNav.getMenu().findItem(R.id.action_meal_plan).setChecked(true);
+    public MealPlanFragment() {
+        super(R.layout.activity_meal_plan);
     }
 
     /**
@@ -38,14 +34,13 @@ public class MealPlanActivity extends NavActivity {
      * @param savedInstanceState {@link Bundle} the last saved instance of the fragment, NULL if newly created
      */
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        // We have to put our layout in the space for the content
-        ViewGroup content = findViewById(R.id.nav_content);
-        getLayoutInflater().inflate(R.layout.activity_meal_plan, content, true);
+        getActivity().setTitle("My Meal Plans");
 
-        // Set the correct button to be selected
-        bottomNav.getMenu().findItem(R.id.action_meal_plan).setChecked(true);
+        // We have to put our layout in the space for the content
+        ViewGroup content = view.findViewById(R.id.nav_content);
+        getLayoutInflater().inflate(R.layout.activity_meal_plan, content, true);
 
         // Get Data
         // TODO create a controller and hook up to Firebase
@@ -56,8 +51,8 @@ public class MealPlanActivity extends NavActivity {
         }
 
         // Attach to listview
-        mealPlanArrayAdapter = new MealPlanListAdapter(this, mealPlanDataList);
-        listView = findViewById(R.id.mealPlanListView);
+        mealPlanArrayAdapter = new MealPlanListAdapter(getContext(), mealPlanDataList);
+        listView = view.findViewById(R.id.mealPlanListView);
         listView.setAdapter(mealPlanArrayAdapter);
     }
 }

--- a/android/301Project/app/src/main/java/com/example/a301project/MealPlanListAdapter.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/MealPlanListAdapter.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 
 /**
  * Class for an ArrayAdapter that renders MealPlan objects for use
- * by a ListView in MealPlanActivity
+ * by a ListView in MealPlanFragment
  */
 public class MealPlanListAdapter extends ArrayAdapter<MealPlan> {
     private ArrayList<MealPlan> mealPlans;

--- a/android/301Project/app/src/main/java/com/example/a301project/NavActivity.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/NavActivity.java
@@ -96,7 +96,6 @@ public class NavActivity extends AppCompatActivity {
      */
     @Override
     public void onBackPressed() {
-        Log.i("cnt", String.valueOf(getSupportFragmentManager().getBackStackEntryCount()));
         if (getSupportFragmentManager().getBackStackEntryCount() > 1) {
             super.onBackPressed();
         } else {

--- a/android/301Project/app/src/main/java/com/example/a301project/NavActivity.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/NavActivity.java
@@ -1,11 +1,13 @@
 package com.example.a301project;
 
-import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MenuItem;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.navigation.NavigationBarView;
@@ -36,28 +38,69 @@ public class NavActivity extends AppCompatActivity {
              */
             @Override
             public boolean onNavigationItemSelected(@NonNull MenuItem item) {
-                // retrive the selected item ID to determine which activity to switch to
+                // Retrieve the selected item ID to determine which activity to switch to
                 // in future prototypes this will become fragments
                 int id = item.getItemId();
-                Intent i = null;
 
-                if (id == R.id.action_ingredients) {
-                    i = new Intent(NavActivity.this, IngredientActivity.class);
-                } else if (id == R.id.action_recipes) {
-                    i = new Intent(NavActivity.this, RecipeActivity.class);
-                } else if (id == R.id.action_meal_plan) {
-                    i = new Intent(NavActivity.this, MealPlanActivity.class);
-                } else if (id == R.id.action_shopping_list) {
-                    i = new Intent(NavActivity.this, ShoppingListActivity.class);
-                }
-
-                i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-
-                // launch the activity that was selected
-                startActivity(i);
+                renderFragment(id);
 
                 return true;
             }
         });
+
+        // Render ingredient by default
+        getSupportFragmentManager().beginTransaction()
+                .replace(R.id.nav_content, IngredientFragment.class, null, "IngredientFragment")
+                .setReorderingAllowed(true)
+                .addToBackStack(null)
+                .commit();
+        bottomNav.getMenu().findItem(R.id.action_ingredients).setChecked(true);
+    }
+
+    /**
+     * Renders the fragment with the given id
+     * @param id id of menu item in the nav bar
+     */
+    private void renderFragment(int id) {
+        // Avoid duplicates if you press button on same screen
+        if (bottomNav.getSelectedItemId() == id) {return;}
+
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        Class<? extends Fragment> f = null;
+        String tag = null;
+
+        if (id == R.id.action_ingredients) {
+            f = IngredientFragment.class;
+            tag = "IngredientFragment";
+        } else if (id == R.id.action_recipes) {
+            f = RecipeFragment.class;
+            tag = "RecipeFragment";
+        } else if (id == R.id.action_meal_plan) {
+            f = MealPlanFragment.class;
+            tag = "MealPlanFragment";
+        } else if (id == R.id.action_shopping_list) {
+            f = ShoppingListFragment.class;
+            tag = "ShoppingListFragment";
+        }
+
+        fragmentManager.beginTransaction()
+                .replace(R.id.nav_content, f, null, tag)
+                .setReorderingAllowed(true)
+                .addToBackStack(null)
+                .commit();
+    }
+
+    /**
+     * Override the back button so when we only have one fragment we close the app
+     * instead of showing a blank screen
+     */
+    @Override
+    public void onBackPressed() {
+        Log.i("cnt", String.valueOf(getSupportFragmentManager().getBackStackEntryCount()));
+        if (getSupportFragmentManager().getBackStackEntryCount() > 1) {
+            super.onBackPressed();
+        } else {
+            finish();
+        }
     }
 }

--- a/android/301Project/app/src/main/java/com/example/a301project/RecipeController.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/RecipeController.java
@@ -15,11 +15,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * This {@link RecipeController} class allows the {@link RecipeActivity} to communicate with
+ * This {@link RecipeController} class allows the {@link RecipeFragment} to communicate with
  * the Firestore database backend. This class contains methods to add or remove {@link Recipe} objects to the
  * database, as well as edit functionality.
  *
- * This class should be used exclusively by the {@link RecipeActivity} class to handle database communication.
+ * This class should be used exclusively by the {@link RecipeFragment} class to handle database communication.
  */
 public class RecipeController {
     private FirebaseFirestore db;

--- a/android/301Project/app/src/main/java/com/example/a301project/RecipeFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/RecipeFragment.java
@@ -2,7 +2,6 @@ package com.example.a301project;
 
 import android.os.Bundle;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -10,6 +9,9 @@ import android.widget.CompoundButton;
 import android.widget.ListView;
 import android.widget.Spinner;
 import android.widget.Switch;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -22,7 +24,7 @@ import java.util.Collections;
  *  handles sorting of recipes
  *  @return void
  */
-public class RecipeActivity extends NavActivity implements AddEditRecipeFragment.OnFragmentInteractionListener {
+public class RecipeFragment extends Fragment implements AddEditRecipeFragment.OnFragmentInteractionListener {
     private ListView listView;
     private ArrayAdapter<Recipe> recipeArrayAdapter;
     private ArrayList<Recipe> recipeDataList = new ArrayList<>();
@@ -33,42 +35,35 @@ public class RecipeActivity extends NavActivity implements AddEditRecipeFragment
     Button addButton;
     public int position = -1;
 
-    /**
-     * Method for the activity becomes active and can receive input
-     * Navigation panel finds the menu and displays it
-     */
-    @Override
-    protected void onResume() {
-        super.onResume();
-        bottomNav.getMenu().findItem(R.id.action_recipes).setChecked(true);
+    public RecipeFragment() {
+        super(R.layout.activity_recipe);
     }
 
     /**
      * Method for initializing attributes of this activity
+     * @param view The View returned by onCreateView.f
      * @param savedInstanceState {@link Bundle} the last saved instance of the fragment, NULL if newly created
      */
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        // We have to put our layout in the space for the content
-        ViewGroup content = findViewById(R.id.nav_content);
-        getLayoutInflater().inflate(R.layout.activity_recipe, content, true);
-        addButton = findViewById(R.id.add_recipe_button);
-        // Set the correct button to be selected
-        bottomNav.getMenu().findItem(R.id.action_recipes).setChecked(true);
+        getActivity().setTitle("My Recipes");
+
+        addButton = view.findViewById(R.id.add_recipe_button);
+
         // Fetch the data
         controller.getRecipes(res -> setRecipeDataList(res));
 
         // Attach to listView
-        recipeArrayAdapter = new RecipeListAdapter(this, recipeDataList);
-        listView = findViewById(R.id.recipeListView);
+        recipeArrayAdapter = new RecipeListAdapter(getContext(), recipeDataList);
+        listView = view.findViewById(R.id.recipeListView);
         listView.setAdapter(recipeArrayAdapter);
 
         // Setup sorting
         // sort by title, prep time, servings, category
-        sortSpinner = findViewById(R.id.recipeSortSpinner);
-        sortSwitch = findViewById(R.id.recipeSortSwitch);
-        ArrayAdapter<String> sortAdapter = new ArrayAdapter<>(this, com.google.android.material.R.layout.support_simple_spinner_dropdown_item, sortOptions);
+        sortSpinner = view.findViewById(R.id.recipeSortSpinner);
+        sortSwitch = view.findViewById(R.id.recipeSortSwitch);
+        ArrayAdapter<String> sortAdapter = new ArrayAdapter<>(getContext(), com.google.android.material.R.layout.support_simple_spinner_dropdown_item, sortOptions);
         sortSpinner.setAdapter(sortAdapter);
         sortSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             /**
@@ -104,7 +99,7 @@ public class RecipeActivity extends NavActivity implements AddEditRecipeFragment
             @Override
             public void onClick(View view) {
                 Recipe newRecipe = new Recipe("","","","", 0L, 0L,new ArrayList<>());
-                AddEditRecipeFragment.newInstance(newRecipe,true).show(getSupportFragmentManager(),"ADD");
+                AddEditRecipeFragment.newInstance(newRecipe,true, RecipeFragment.this).show(getChildFragmentManager(),"ADD");
             }
         });
         sortSwitch.setChecked(true);
@@ -134,8 +129,7 @@ public class RecipeActivity extends NavActivity implements AddEditRecipeFragment
             public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
                 // when a Recipe item is clicked, open Edit Recipe fragment
                 position = i;
-                Recipe selected = (Recipe) adapterView.getItemAtPosition(i);
-                AddEditRecipeFragment.newInstance(recipeArrayAdapter.getItem(position), false).show(getSupportFragmentManager(), "EDIT");
+                AddEditRecipeFragment.newInstance(recipeArrayAdapter.getItem(position), false, RecipeFragment.this).show(getChildFragmentManager(), "EDIT");
             }
         });
 
@@ -158,8 +152,8 @@ public class RecipeActivity extends NavActivity implements AddEditRecipeFragment
      */
     private void sortDataBySpinner() {
         // Make sure views are defined
-        sortSpinner = findViewById(R.id.recipeSortSpinner);
-        sortSwitch = findViewById(R.id.recipeSortSwitch);
+        sortSpinner = getView().findViewById(R.id.recipeSortSpinner);
+        sortSwitch = getView().findViewById(R.id.recipeSortSwitch);
 
         String sortBy = sortSpinner.getSelectedItem().toString();
         Integer asc = sortSwitch.isChecked() ? 1 : -1;

--- a/android/301Project/app/src/main/java/com/example/a301project/ShoppingListController.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/ShoppingListController.java
@@ -1,19 +1,16 @@
 package com.example.a301project;
 
-import android.util.Log;
-
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 import java.util.ArrayList;
-import java.util.Map;
 
 /**
- * This {@link ShoppingListController} class allows the {@link ShoppingListActivity} to communicate with
+ * This {@link ShoppingListController} class allows the {@link ShoppingListFragment} to communicate with
  * the Firestore database backend. This class contains methods to add or remove {@link Recipe} objects to the
  * database, as well as edit functionality.
  *
- * This class should be used exclusively by the {@link ShoppingListActivity} class to handle database communication.
+ * This class should be used exclusively by the {@link ShoppingListFragment} class to handle database communication.
  */
 public class ShoppingListController {
     private FirebaseFirestore db;

--- a/android/301Project/app/src/main/java/com/example/a301project/ShoppingListFragment.java
+++ b/android/301Project/app/src/main/java/com/example/a301project/ShoppingListFragment.java
@@ -10,6 +10,9 @@ import android.widget.ListView;
 import android.widget.Spinner;
 import android.widget.Switch;
 
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -21,7 +24,7 @@ import java.util.Collections;
  *  handles sorting
  *  @return void
  */
-public class ShoppingListActivity extends NavActivity {
+public class ShoppingListFragment extends Fragment {
     private ListView listView;
     private ArrayAdapter<ShoppingItem> shoppingItemArrayAdapter;
     private ArrayList<ShoppingItem> shoppingItemDataList = new ArrayList<>();
@@ -30,43 +33,36 @@ public class ShoppingListActivity extends NavActivity {
     private Spinner sortSpinner;
     private Switch sortSwitch;
 
-    /**
-     * Method for the activity becomes active and can receive input
-     * Navigation panel finds the menu and displays it
-     */
-    @Override
-    protected void onResume() {
-        super.onResume();
-        bottomNav.getMenu().findItem(R.id.action_shopping_list).setChecked(true);
+    public ShoppingListFragment() {
+        super(R.layout.activity_shopping_list);
     }
 
     /**
      * Method for initializing attributes of this activity
+     * @param view The View returned by onCreateView.f
      * @param savedInstanceState {@link Bundle} the last saved instance of the fragment, NULL if newly created
      */
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getActivity().setTitle("My Shopping List");
 
         // We have to put our layout in the space for the content
-        ViewGroup content = findViewById(R.id.nav_content);
+        ViewGroup content = view.findViewById(R.id.nav_content);
         getLayoutInflater().inflate(R.layout.activity_shopping_list, content, true);
-
-        // Set the correct button to be selected
-        bottomNav.getMenu().findItem(R.id.action_shopping_list).setChecked(true);
 
         // Fetch the data
         controller.getShoppingItems(res -> setShoppingItemDataList(res));
 
         // Attach to listView
-        shoppingItemArrayAdapter = new ShoppingListAdapter(this, shoppingItemDataList);
-        listView = findViewById(R.id.shoppingItemListView);
+        shoppingItemArrayAdapter = new ShoppingListAdapter(getContext(), shoppingItemDataList);
+        listView = view.findViewById(R.id.shoppingItemListView);
         listView.setAdapter(shoppingItemArrayAdapter);
 
         // Setup sorting
-        sortSpinner = findViewById(R.id.shoppingSortSpinner);
-        sortSwitch = findViewById(R.id.shoppingSortSwitch);
-        ArrayAdapter<String> sortAdapter = new ArrayAdapter<>(this, com.google.android.material.R.layout.support_simple_spinner_dropdown_item, sortOptions);
+        sortSpinner = view.findViewById(R.id.shoppingSortSpinner);
+        sortSwitch = view.findViewById(R.id.shoppingSortSwitch);
+        ArrayAdapter<String> sortAdapter = new ArrayAdapter<>(getContext(), com.google.android.material.R.layout.support_simple_spinner_dropdown_item, sortOptions);
         sortSpinner.setAdapter(sortAdapter);
         sortSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             /**
@@ -124,8 +120,8 @@ public class ShoppingListActivity extends NavActivity {
      */
     private void sortDataBySpinner() {
         // Make sure views are defined
-        sortSpinner = findViewById(R.id.shoppingSortSpinner);
-        sortSwitch = findViewById(R.id.shoppingSortSwitch);
+        sortSpinner = getView().findViewById(R.id.shoppingSortSpinner);
+        sortSwitch = getView().findViewById(R.id.shoppingSortSwitch);
 
         String sortBy = sortSpinner.getSelectedItem().toString();
         Integer asc = sortSwitch.isChecked() ? 1 : -1;

--- a/android/301Project/app/src/main/res/layout/activity_meal_plan.xml
+++ b/android/301Project/app/src/main/res/layout/activity_meal_plan.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MealPlanActivity">
+    tools:context=".MealPlanFragment">
     <ListView
         android:id="@+id/mealPlanListView"
         android:layout_width="0dp"

--- a/android/301Project/app/src/main/res/layout/activity_shopping_list.xml
+++ b/android/301Project/app/src/main/res/layout/activity_shopping_list.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ShoppingListActivity">
+    tools:context=".ShoppingListFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/shoppingSort"

--- a/android/301Project/app/src/test/java/com/example/a301project/IngredientControllerTest.java
+++ b/android/301Project/app/src/test/java/com/example/a301project/IngredientControllerTest.java
@@ -3,16 +3,12 @@ package com.example.a301project;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
-import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.CollectionReference;
-import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mockito;
 
 import java.util.Map;
 


### PR DESCRIPTION
# Description
On TA request, refactor all instance of activity screens to fragments.

Resolves #83
* NavActivity now renders a fragment based on the screen 
* Make classes extend fragment now 
* Change the onCreate to onCreateView
* Rename view to getView
* Remove onAttach
* Make listeners passed in by the newInstance func because context is still pointing to NavActivity
* Updated tests accordingly